### PR TITLE
feat: add json-schema to docs deploy

### DIFF
--- a/docs/json-schema
+++ b/docs/json-schema
@@ -1,0 +1,1 @@
+../json-schema


### PR DESCRIPTION
I don't see any reason why we can't use github pages to serve our json-schema? That gives us versioning (via mike) as well.

This popped up because I was updating the original stac-utils/stac-geoparquet repo and noticed some of the tests reference the json-schema.

To test:

```sh
mkdocs serve
```

Then, go to http://127.0.0.1:8000/stac-geoparquet-spec/json-schema/metadata.json