### PR TITLE
release: v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ A specification for storing
 [GeoParquet](https://geoparquet.org/). The specification lives at
 <https://radiantearth.github.io/stac-geoparquet-spec>.
 
-<!-- prettier-ignore -->
-> [!WARNING]
-> The **stac-geoparquet** specification is under development, and has
-> not yet been released as a stable v1. See
-> [this milestone](https://github.com/radiantearth/stac-geoparquet-spec/milestone/1)
-> to track progress towards a stable release.
-
 ## Motivation
 
 The STAC spec is defined in terms of JSON, but it can be hard to manage and

--- a/example-metadata.json
+++ b/example-metadata.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "collections": {
         "simple-collection": {
             "id": "simple-collection",


### PR DESCRIPTION
An "official" v1.1.0 release of the specification document, which I'll tag in Github Releases after this PR is merged.

See https://github.com/stac-utils/stac-geoparquet/pull/98 for context on why the spec document text is at v1.1.0 instead of v1.0.0.

I'll _also_ go back and find a good commit to tag with v1.0.0 to capture that state, as well.