### PR TITLE
chore: fixes and updates to ci and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      uv:
+        patterns:
+          - "*"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,4 +22,4 @@ jobs:
           # Get most recent git tag
           # https://stackoverflow.com/a/7261049
           VERSION=$(git describe --tags --abbrev=0)
-          mike deploy $VERSION latest --update-aliases --push
+          uv run mike deploy $VERSION latest --update-aliases --push

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Deploy docs
         env:
           GIT_COMMITTER_NAME: CI


### PR DESCRIPTION
Pages deploy didn't work for release: https://github.com/radiantearth/stac-geoparquet-spec/actions/runs/31510942895/job/93844305812